### PR TITLE
add build-essential and pkg-config to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tested on ubuntu 16.04 LTS
 
 ```
 sudo apt update
-sudo apt install cmake libnl-3-dev libnl-genl-3-dev
+sudo apt install cmake libnl-3-dev libnl-genl-3-dev build-essential pkg-config
 ```
 
 # install


### PR DESCRIPTION
add `build-essential` and `pkg-config` to build dependencies
I needed these on a fresh Ubuntu 16.04 droplet